### PR TITLE
fixed missing commit in core.py

### DIFF
--- a/natu/core.py
+++ b/natu/core.py
@@ -736,6 +736,7 @@ class Quantity(DimObject):
         """
         return self._value.__getitem__(item)
 
+
     def __getattr__(self, attr):
         """If an attribute is unknown, look for it within :attr:`_value`.  If
         the attribute's value is a property, return it.  If it is a method,
@@ -755,6 +756,8 @@ class Quantity(DimObject):
 
         .. _NumPy: http://numpy.scipy.org/
         """
+        if '_value' not in dir(self):
+            raise AttributeError()
         attr_value = getattr(self._value, attr)
         if callable(attr_value):
             def new_meth(*args, **kwargs):

--- a/natu/core.py
+++ b/natu/core.py
@@ -163,7 +163,7 @@ import re
 
 from os.path import dirname
 from types import ModuleType
-from functools import wraps
+from functools import wraps, reduce
 # from warnings import warn
 from .util import format_e
 from ._prefixes import PREFIXES


### PR DESCRIPTION
@kdavies4 hello, missing import of reduce caused following crash in python3

```
>>> from natu.units import K
>>> 1.*K
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.4/site-packages/natu/core.py", line 823, in __repr__
    return format(self, 'g')
  File "/usr/lib/python3.4/site-packages/natu/core.py", line 357, in wrapped
    unit = unitspace(**display_unit)
  File "/usr/lib/python3.4/site-packages/natu/core.py", line 1374, in __call__
    return reduce(lambda x, y: x * y, factors)
NameError: name 'reduce' is not defined
>>> 
```

added import  of reduce in core.py source file to make it work:

```
>>> from natu.units import K
>>> 1.*K
1 K
>>> 
```

i would also like to take the opportunity to say "thank you" for sharing this wonderful library =) 